### PR TITLE
Fix typo in `Greedy Params` example

### DIFF
--- a/src/routes/itty-router/route-patterns/+page.md
+++ b/src/routes/itty-router/route-patterns/+page.md
@@ -81,7 +81,7 @@ router.get('/goto/:url+', handler)
 Returns the following params:
 ```json
 { 
-  "url": "https:/google.com"
+  "url": "https://google.com"
 }
 ```
 


### PR DESCRIPTION
URL missing a `/`