### PR TITLE
Missing AutoRouter Instantiation in Getting Started 

### DIFF
--- a/itty-router/getting-started.md
+++ b/itty-router/getting-started.md
@@ -151,6 +151,8 @@ In the example, [`Router`](/itty-router/routers/router) uses stages to create `R
 ```ts [AutoRouter]
 import { AutoRouter } from 'itty-router'
 
+const router = AutoRouter()
+
 router
   .get('/hello/:name', ({ name }) => `Hello, ${name}!`)
   .get('/json', () => ({ foo: 'bar' }))


### PR DESCRIPTION
**Getting Started -> Complete Example -> AutoRouter**

```diff
import { AutoRouter } from 'itty-router'

+ const router = AutoRouter()

router
  .get('/hello/:name', ({ name }) => `Hello, ${name}!`)
  .get('/json', () => ({ foo: 'bar' }))
  .get('/throw', (a) => a.b.c) // safely throws

export default router
```