### PR TITLE
fix: update docs from handle to fetch

### DIFF
--- a/itty-router/migrations/v4-v5.md
+++ b/itty-router/migrations/v4-v5.md
@@ -52,7 +52,7 @@ router.get('/', () => 'Success!')
 export default {
   fetch: (request, ...args) => 
     router
-      .handle(request, ...args)
+      .fetch(request, ...args)
       .then(json)
       .catch(error)
       .then(corsify) // [!code --]


### PR DESCRIPTION
handle is deprecated in v5 right?
the reference wasn't updated here.