### PR TITLE
Replace itty-router-openapi with chanfana in Community Projects

### DIFF
--- a/itty-router/community-projects.md
+++ b/itty-router/community-projects.md
@@ -5,6 +5,6 @@ These addons from our wonderful community give itty-router addional functionalit
 - [@major-tanya/fancy-status](https://www.npmjs.com/package/@major-tanya/fancy-status) - A convenient wrapper library to return certain status code responses.
 - [@major-tanya/itty-compression](https://www.npmjs.com/package/@major-tanya/itty-compression) - add compression to Node+itty APIs.
 - [itty-fs-router](https://www.npmjs.com/package/itty-fs-router) - a file system based router based on itty.
-- [itty-router-openapi](https://www.npmjs.com/package/@cloudflare/itty-router-openapi) - official OpenAPI implementation of itty, by [@cloudflare](https://github.com/cloudflare).
+- [chanfana](https://www.npmjs.com/package/chanfana) - OpenAPI 3 and 3.1 schema generator & validator with support for itty-router, by [@cloudflare](https://github.com/cloudflare).
 <!-- - [dtty](https://www.npmjs.com/package/dtty-extra) - Dependency Injection + Itty = a web framework for Cloudflare workers inspired by NestJS.
 - [dtty-extra](https://www.npmjs.com/package/dtty-extra) - Dependency Injection + Itty = a web framework for Cloudflare workers inspired by NestJS. -->


### PR DESCRIPTION
Project got renamed in early December to expand the supported libraries. The NPM listing is still available but not updated any more with newer changes.

cf. https://github.com/cloudflare/chanfana/pull/151