### PR TITLE
Re-add CF Workers destructuring workaround note

### DIFF
--- a/itty-router/guides/cloudflare-workers.md
+++ b/itty-router/guides/cloudflare-workers.md
@@ -13,4 +13,12 @@ router.get('/', () => 'Success!')
 export default router // see note below
 ```
 
+<Badge type="danger">
+  <p>If you are getting a "The script will never generate a response" warning, destructure your root router like this:</p>
+
+  ```ts
+  export default { ...router } // this looks pointless, but trust us
+  ```
+</Badge>
+
 It's also possible to [setup proper types for the Worker environment and execution context](/itty-router/typescript/additional-arguments#typed-example-assumes-cloudflare-workers).


### PR DESCRIPTION
A user mentioned encountering the "This script will never generate a response" warning when running `vite dev` in a Vite+Typescript+Preact project for Cloudflare Workers. They were using wrangler 4.11.1, so the previously linked wrangler issue shouldn't be relevant (that one also didn't cause this warning if I'm not mistaken).

On a hunch, I asked them to try the classic destructuring workaround and it worked.

Not sure if this is an issue with vite, wrangler, Preact, or any other component in the mix in their project, but it seems this will be useful to people still.

(and the comment referring to the note was still in the code block anyway, so)

Note: I'm not entirely sure what the exact warning text should be, but I believe this "in case of this error, try that" version should be sufficient for people trying to follow the guide.